### PR TITLE
Element value should be preserved on load

### DIFF
--- a/js/jquery.placeholder.js
+++ b/js/jquery.placeholder.js
@@ -15,7 +15,7 @@
     $(':input[placeholder]').each(function(index) {
         var el = $(this);
         var placeholderText = el.attr('placeholder');
-        el.val(placeholderText);
+	if (el.val() === '') el.val(placeholderText);
         el.bind('focus blur', function(e) {
             if (e.type === 'focus' && el.val() === placeholderText) el.val(''); 
             if (e.type === 'blur' && el.val() === '') el.val(placeholderText); 


### PR DESCRIPTION
Hey,

Just a small fix. If the input element has a value when the page is loaded, that value should stay, instead of overwriting with the placeholder text.

Cheers,
Mitchell
