### PR TITLE
Trivially allow the plugin to act as an AMD module under RequireJS etc.

### DIFF
--- a/js/jquery.placeholder.js
+++ b/js/jquery.placeholder.js
@@ -1,4 +1,10 @@
-(function($) {
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(['jquery'], factory);
+	} else {
+		factory(jQuery);
+	}
+}(function ($) {
 
 	/**
 	 * Spoofs placeholders in browsers that don't support them (eg Firefox 3)
@@ -78,4 +84,4 @@
 			if ($(this).val() === $(this).attr('placeholder')) $(this).val('');
 		});
 	}
-})(jQuery);
+}));


### PR DESCRIPTION
Plugin authors are widely adapting their plugins to work as AMD modules,
particularly now that jQuery itself is AMD-compatible. This small change
makes this module work either as normal, or as an AMD module when used in
such an environment (e.g. RequireJS).

Info about AMD: https://github.com/amdjs/amdjs-api/wiki/AMD

Handy module templates: https://github.com/umdjs/umd
